### PR TITLE
Added canvas-drawn identifier text to tiles in effect mode

### DIFF
--- a/resources/js/visualHandling.js
+++ b/resources/js/visualHandling.js
@@ -1295,7 +1295,8 @@ function deleteSelectedEffects(){
     selectedEffects = [];
 
     // must redraw to update identifier text
-    redrawCanvas();
+    // redrawCanvas();
+    updatePositions(); // this also calls redrawCanvas() but redraws the notes too
 }
 
 function deselectNotes(){
@@ -1313,6 +1314,7 @@ function deselectNotes(){
                 document.getElementById(`b${n}`).style.opacity = "0";
             }
             selectedEffects = [];
+            updatePositions(); // so the effect numbering doesn't linger
         }
     }
 }
@@ -1335,7 +1337,8 @@ function setSelectedEffects(cell){
     }
 
     // must redraw to update identifier text
-    redrawCanvas();
+    // redrawCanvas();
+    updatePositions(); // this also calls redrawCanvas() but redraws the notes too
 }
 
 

--- a/resources/js/visualHandling.js
+++ b/resources/js/visualHandling.js
@@ -1044,6 +1044,29 @@ function redrawCanvas(){
             }
         }
     }
+
+    //draw identifier text for tiles in effect mode
+    if (selectedEffects.length > 0) {
+        // the offset used from the tile's top left
+        // important: the drawn text's pivot point is it's bottom left
+        let selectedEffectsTextOffset = {x:8, y:44};
+
+        ctx.fillStyle = "rgba(255,255,255)";
+        ctx.font = "48px serif"
+
+        let index = 1;
+        //entries are added to selectedEffects sequentially
+        for (t of selectedEffects) {
+            let x = t.substring(0, 1);
+            let y = t.substring(1, 2);
+            try {
+                ctx.fillText(`${index}`, gridPositions[x][y].x + selectedEffectsTextOffset.x, gridPositions[x][y].y + selectedEffectsTextOffset.y);
+            } catch (exception) {
+                console.warn(exception.message);
+            }
+            index++;
+        }
+    }
 }
 
 function fireExplosions(){
@@ -1270,6 +1293,9 @@ function deleteSelectedEffects(){
         document.getElementById(`b${e}`).style.opacity = 0;
     }
     selectedEffects = [];
+
+    // must redraw to update identifier text
+    redrawCanvas();
 }
 
 function deselectNotes(){
@@ -1307,6 +1333,9 @@ function setSelectedEffects(cell){
         selectedEffects.push(cell);
         document.getElementById(`b${cell}`).style.opacity = "1";
     }
+
+    // must redraw to update identifier text
+    redrawCanvas();
 }
 
 


### PR DESCRIPTION
In effect mode, selected tiles will display their order of selection via canvas-drawn text.

This change causes the canvas to be redrawn when the selected tiles are modified.

The function _renderEffects(effect)_ directly modifies the selectedEffects array, but I decided based on the function's call hierarchy that redrawing is not necessary at that point, and may cause unintended side effects.